### PR TITLE
LPS 154019

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -35,6 +35,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 
 <c:if test='<%= !(boolean)data.get("isSegmentationEnabled") %>'>
 	<clay:stripe
+		dismissible="<%= true %>"
 		displayType="warning"
 	>
 		<strong class="lead"><%= LanguageUtil.get(request, "personalized-variations-can-not-be-displayed-because-segmentation-is-disabled") %></strong>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -421,6 +421,8 @@ const ExperiencesSelectorHeader = ({
 	onNewExperience,
 	showEmptyStateMessage,
 }) => {
+	const [dismissAlert, setDismissAlert] = useState(false);
+
 	return (
 		<>
 			<ClayLayout.ContentRow className="mb-3" verticalAlign="center">
@@ -456,11 +458,15 @@ const ExperiencesSelectorHeader = ({
 				</p>
 			)}
 
-			{!config.isSegmentationEnabled ? (
-				<ClayAlert className="mx-0" displayType="warning">
+			{!config.isSegmentationEnabled && !dismissAlert ? (
+				<ClayAlert
+					className="mx-0"
+					displayType="warning"
+					onClose={() => setDismissAlert(true)}
+				>
 					<strong className="lead">
 						{Liferay.Language.get(
-							'experiences-cannot-be-displayed-because-segmentation-is-disabled'
+							'experiences-can-not-be-displayed-because-segmentation-is-disabled'
 						)}
 					</strong>
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -460,11 +460,11 @@ const ExperiencesSelectorHeader = ({
 
 			{!config.isSegmentationEnabled && !dismissAlert ? (
 				<ClayAlert
-					className="mx-0"
+					className="mx-0 segmentation-disabled-alert"
 					displayType="warning"
 					onClose={() => setDismissAlert(true)}
 				>
-					<strong className="lead">
+					<strong className="d-block lead">
 						{Liferay.Language.get(
 							'experiences-can-not-be-displayed-because-segmentation-is-disabled'
 						)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -466,7 +466,7 @@ const ExperiencesSelectorHeader = ({
 				>
 					<strong className="d-block lead">
 						{Liferay.Language.get(
-							'experiences-can-not-be-displayed-because-segmentation-is-disabled'
+							'experiences-cannot-be-displayed-because-segmentation-is-disabled'
 						)}
 					</strong>
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/_ExperienceToolbarSection.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/_ExperienceToolbarSection.scss
@@ -38,6 +38,12 @@ html#{$cadmin-selector} {
 					border: 1px solid $cadmin-primary-l1;
 				}
 			}
+
+			.segmentation-disabled-alert {
+				line-height: inherit;
+				margin: inherit;
+				padding: 15px 16px;
+			}
 		}
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -235,7 +235,7 @@ describe('ExperienceToolbarSection', () => {
 
 		const icons = getAllByRole('presentation');
 
-		const lockIcon = icons[1];
+		const lockIcon = icons[2];
 
 		// Hackily work around:
 		//

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/ContributorsBuilder.es.js
@@ -40,6 +40,7 @@ class ContributorBuilder extends React.Component {
 		contributors: PropTypes.arrayOf(contributorShape),
 		editing: PropTypes.bool.isRequired,
 		emptyContributors: PropTypes.bool.isRequired,
+		isSegmentationDisabledAlertDismissed: PropTypes.bool,
 		isSegmentationEnabled: PropTypes.bool,
 		membersCount: PropTypes.number,
 		membersCountLoading: PropTypes.bool,
@@ -101,6 +102,7 @@ class ContributorBuilder extends React.Component {
 			contributors,
 			editing,
 			emptyContributors,
+			isSegmentationDisabledAlertDismissed,
 			isSegmentationEnabled,
 			membersCount,
 			membersCountLoading,
@@ -120,8 +122,11 @@ class ContributorBuilder extends React.Component {
 			editing,
 		});
 
+		const showDisabledSegmentationAlert =
+			!isSegmentationEnabled && !isSegmentationDisabledAlertDismissed;
+
 		const sidebarClasses = getCN('criteria-builder-section-sidebar', {
-			'criteria-builder-section-sidebar--with-warning': !isSegmentationEnabled,
+			'criteria-builder-section-sidebar--with-warning': showDisabledSegmentationAlert,
 		});
 
 		return (

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -99,6 +99,7 @@ class SegmentEdit extends Component {
 			disabledSave: this._isQueryEmpty(contributors),
 			editing: showInEditMode,
 			hasChanged: false,
+			isSegmentationDisabledAlertDismissed: false,
 			membersCount: initialMembersCount,
 			queryHasEmptyValues: false,
 			validTitle: !!values.name[props.defaultLanguageId],
@@ -267,6 +268,9 @@ class SegmentEdit extends Component {
 				contributors={contributors}
 				editing={editing}
 				emptyContributors={emptyContributors}
+				isSegmentationDisabledAlertDismissed={
+					this.state.isSegmentationDisabledAlertDismissed
+				}
 				isSegmentationEnabled={this.props.isSegmentationEnabled}
 				membersCount={membersCount}
 				membersCountLoading={membersCountLoading}
@@ -539,23 +543,29 @@ class SegmentEdit extends Component {
 				</div>
 
 				<div className="form-body">
-					{!this.props.isSegmentationEnabled && (
-						<ClayAlert
-							className="mx-0"
-							displayType="warning"
-							variant="stripe"
-						>
-							<strong className="lead">
-								{Liferay.Language.get(
-									'segmentation-is-disabled'
-								)}
-							</strong>
+					{!this.props.isSegmentationEnabled &&
+						!this.state.isSegmentationDisabledAlertDismissed && (
+							<ClayAlert
+								className="mx-0"
+								displayType="warning"
+								onClose={() =>
+									this.setState({
+										isSegmentationDisabledAlertDismissed: true,
+									})
+								}
+								variant="stripe"
+							>
+								<strong className="lead">
+									{Liferay.Language.get(
+										'segmentation-is-disabled'
+									)}
+								</strong>
 
-							{Liferay.Language.get(
-								'to-enable-segmentation-go-to-system-settings-segments-segments-service'
-							)}
-						</ClayAlert>
-					)}
+								{Liferay.Language.get(
+									'to-enable-segmentation-go-to-system-settings-segments-segments-service'
+								)}
+							</ClayAlert>
+						)}
 
 					<FieldArray
 						name="contributors"

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/segment_edit/SegmentEdit.es.js
@@ -445,6 +445,7 @@ class SegmentEdit extends Component {
 			availableLocales,
 			defaultLanguageId,
 			hasUpdatePermission,
+			isSegmentationEnabled,
 			portletNamespace,
 			values,
 		} = this.props;
@@ -453,6 +454,7 @@ class SegmentEdit extends Component {
 			contributors,
 			disabledSave,
 			editing,
+			isSegmentationDisabledAlertDismissed,
 			queryHasEmptyValues,
 			validTitle,
 		} = this.state;
@@ -461,12 +463,14 @@ class SegmentEdit extends Component {
 
 		const placeholder = Liferay.Language.get('untitled-segment');
 
+		const showDisabledSegmentationAlert =
+			!isSegmentationEnabled && !isSegmentationDisabledAlertDismissed;
+
 		return (
 			<div
 				className={classNames('segment-edit-page-root', {
 					'segment-edit-page-root--has-alert': queryHasEmptyValues,
-					'segment-edit-page-root--with-warning': !this.props
-						.isSegmentationEnabled,
+					'segment-edit-page-root--with-warning': showDisabledSegmentationAlert,
 				})}
 			>
 				<input
@@ -543,29 +547,28 @@ class SegmentEdit extends Component {
 				</div>
 
 				<div className="form-body">
-					{!this.props.isSegmentationEnabled &&
-						!this.state.isSegmentationDisabledAlertDismissed && (
-							<ClayAlert
-								className="mx-0"
-								displayType="warning"
-								onClose={() =>
-									this.setState({
-										isSegmentationDisabledAlertDismissed: true,
-									})
-								}
-								variant="stripe"
-							>
-								<strong className="lead">
-									{Liferay.Language.get(
-										'segmentation-is-disabled'
-									)}
-								</strong>
-
+					{showDisabledSegmentationAlert && (
+						<ClayAlert
+							className="mx-0"
+							displayType="warning"
+							onClose={() =>
+								this.setState({
+									isSegmentationDisabledAlertDismissed: true,
+								})
+							}
+							variant="stripe"
+						>
+							<strong className="lead">
 								{Liferay.Language.get(
-									'to-enable-segmentation-go-to-system-settings-segments-segments-service'
+									'segmentation-is-disabled'
 								)}
-							</ClayAlert>
-						)}
+							</strong>
+
+							{Liferay.Language.get(
+								'to-enable-segmentation-go-to-system-settings-segments-segments-service'
+							)}
+						</ClayAlert>
+					)}
 
 					<FieldArray
 						name="contributors"

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -43,6 +43,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 
 <c:if test="<%= !segmentsDisplayContext.isSegmentationEnabled(themeDisplay.getCompanyId()) %>">
 	<clay:stripe
+		dismissible="<%= true %>"
 		displayType="warning"
 	>
 		<strong class="lead"><%= LanguageUtil.get(request, "segmentation-is-disabled") %></strong>

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/SegmentEdit.es.js
@@ -63,6 +63,7 @@ function _renderSegmentEditComponent({
 	hasUpdatePermission = undefined,
 	contributors = undefined,
 	showInEditMode = undefined,
+	isSegmentationEnabled = true,
 } = {}) {
 	return render(
 		<SegmentEdit
@@ -75,6 +76,7 @@ function _renderSegmentEditComponent({
 			initialSegmentName={{
 				en_US: 'Segment title',
 			}}
+			isSegmentationEnabled={isSegmentationEnabled}
 			locale="en_US"
 			redirect={redirect}
 			showInEditMode={showInEditMode}
@@ -195,5 +197,60 @@ describe('SegmentEdit', () => {
 			);
 			done();
 		});
+	});
+
+	it('renders a dissmisible alert if Segmentation service is disabled', () => {
+		const isSegmentationEnabled = false;
+
+		const {container, getByText} = _renderSegmentEditComponent({
+			isSegmentationEnabled,
+		});
+
+		expect(getByText('segmentation-is-disabled')).toBeInTheDocument();
+
+		expect(
+			container.getElementsByClassName(
+				'segment-edit-page-root--with-warning'
+			).length
+		).toBe(1);
+
+		expect(
+			container.querySelectorAll(
+				'.alert-dismissible .lexicon-icon.lexicon-icon-times'
+			).length
+		).toBe(1);
+	});
+
+	it('renders a dismissible alert which is effectively dismissible', async () => {
+		const isSegmentationEnabled = false;
+
+		const {
+			container,
+			getByLabelText,
+			getByText,
+			queryByText,
+		} = _renderSegmentEditComponent({
+			isSegmentationEnabled,
+		});
+
+		expect(getByText('segmentation-is-disabled')).toBeInTheDocument();
+
+		const dismissButton = getByLabelText('Close', {selector: 'button'});
+
+		fireEvent.click(dismissButton);
+
+		expect(queryByText('segmentation-is-disabled')).not.toBeInTheDocument();
+
+		expect(
+			container.querySelectorAll(
+				'.alert-dismissible .lexicon-icon.lexicon-icon-times'
+			).length
+		).toBe(0);
+
+		expect(
+			container.getElementsByClassName(
+				'segment-edit-page-root--with-warning'
+			).length
+		).toBe(0);
 	});
 });

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
@@ -91,7 +91,7 @@ exports[`SegmentEdit renders 1`] = `
       class="form-body"
     >
       <div
-        class="mx-0 alert alert-fluid alert-warning"
+        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
         role="alert"
       >
         <div
@@ -135,6 +135,20 @@ exports[`SegmentEdit renders 1`] = `
               </div>
             </div>
           </div>
+          <button
+            aria-label="Close"
+            class="close"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-times"
+              role="presentation"
+            >
+              <use
+                xlink:href="#times"
+              />
+            </svg>
+          </button>
         </div>
       </div>
     </div>
@@ -313,7 +327,7 @@ exports[`SegmentEdit renders with edit buttons if the user has update permission
       class="form-body"
     >
       <div
-        class="mx-0 alert alert-fluid alert-warning"
+        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
         role="alert"
       >
         <div
@@ -357,6 +371,20 @@ exports[`SegmentEdit renders with edit buttons if the user has update permission
               </div>
             </div>
           </div>
+          <button
+            aria-label="Close"
+            class="close"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-times"
+              role="presentation"
+            >
+              <use
+                xlink:href="#times"
+              />
+            </svg>
+          </button>
         </div>
       </div>
     </div>
@@ -534,7 +562,7 @@ exports[`SegmentEdit renders with given values 1`] = `
       class="form-body"
     >
       <div
-        class="mx-0 alert alert-fluid alert-warning"
+        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
         role="alert"
       >
         <div
@@ -578,6 +606,20 @@ exports[`SegmentEdit renders with given values 1`] = `
               </div>
             </div>
           </div>
+          <button
+            aria-label="Close"
+            class="close"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-times"
+              role="presentation"
+            >
+              <use
+                xlink:href="#times"
+              />
+            </svg>
+          </button>
         </div>
       </div>
       <div
@@ -992,7 +1034,7 @@ exports[`SegmentEdit renders without edit buttons if the user does not have upda
       class="form-body"
     >
       <div
-        class="mx-0 alert alert-fluid alert-warning"
+        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
         role="alert"
       >
         <div
@@ -1036,6 +1078,20 @@ exports[`SegmentEdit renders without edit buttons if the user does not have upda
               </div>
             </div>
           </div>
+          <button
+            aria-label="Close"
+            class="close"
+            type="button"
+          >
+            <svg
+              class="lexicon-icon lexicon-icon-times"
+              role="presentation"
+            >
+              <use
+                xlink:href="#times"
+              />
+            </svg>
+          </button>
         </div>
       </div>
     </div>

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.es.js.snap
@@ -3,7 +3,7 @@
 exports[`SegmentEdit renders 1`] = `
 <DocumentFragment>
   <div
-    class="segment-edit-page-root segment-edit-page-root--with-warning"
+    class="segment-edit-page-root"
   >
     <input
       name="active"
@@ -89,69 +89,7 @@ exports[`SegmentEdit renders 1`] = `
     </div>
     <div
       class="form-body"
-    >
-      <div
-        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
-        role="alert"
-      >
-        <div
-          class="container"
-        >
-          <div
-            class="alert-autofit-row autofit-row"
-          >
-            <div
-              class="autofit-col"
-            >
-              <div
-                class="autofit-section"
-              >
-                <span
-                  class="alert-indicator"
-                >
-                  <svg
-                    class="lexicon-icon lexicon-icon-warning-full"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="#warning-full"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-            <div
-              class="autofit-col autofit-col-expand"
-            >
-              <div
-                class="autofit-section"
-              >
-                <strong
-                  class="lead"
-                >
-                  segmentation-is-disabled
-                </strong>
-                to-enable-segmentation-go-to-system-settings-segments-segments-service
-              </div>
-            </div>
-          </div>
-          <button
-            aria-label="Close"
-            class="close"
-            type="button"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-times"
-              role="presentation"
-            >
-              <use
-                xlink:href="#times"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-    </div>
+    />
   </div>
 </DocumentFragment>
 `;
@@ -159,7 +97,7 @@ exports[`SegmentEdit renders 1`] = `
 exports[`SegmentEdit renders with edit buttons if the user has update permissions 1`] = `
 <DocumentFragment>
   <div
-    class="segment-edit-page-root segment-edit-page-root--with-warning"
+    class="segment-edit-page-root"
   >
     <input
       name="active"
@@ -325,69 +263,7 @@ exports[`SegmentEdit renders with edit buttons if the user has update permission
     </div>
     <div
       class="form-body"
-    >
-      <div
-        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
-        role="alert"
-      >
-        <div
-          class="container"
-        >
-          <div
-            class="alert-autofit-row autofit-row"
-          >
-            <div
-              class="autofit-col"
-            >
-              <div
-                class="autofit-section"
-              >
-                <span
-                  class="alert-indicator"
-                >
-                  <svg
-                    class="lexicon-icon lexicon-icon-warning-full"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="#warning-full"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-            <div
-              class="autofit-col autofit-col-expand"
-            >
-              <div
-                class="autofit-section"
-              >
-                <strong
-                  class="lead"
-                >
-                  segmentation-is-disabled
-                </strong>
-                to-enable-segmentation-go-to-system-settings-segments-segments-service
-              </div>
-            </div>
-          </div>
-          <button
-            aria-label="Close"
-            class="close"
-            type="button"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-times"
-              role="presentation"
-            >
-              <use
-                xlink:href="#times"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-    </div>
+    />
   </div>
 </DocumentFragment>
 `;
@@ -946,7 +822,7 @@ exports[`SegmentEdit renders with given values 1`] = `
 exports[`SegmentEdit renders without edit buttons if the user does not have update permissions 1`] = `
 <DocumentFragment>
   <div
-    class="segment-edit-page-root segment-edit-page-root--with-warning"
+    class="segment-edit-page-root"
   >
     <input
       name="active"
@@ -1032,69 +908,7 @@ exports[`SegmentEdit renders without edit buttons if the user does not have upda
     </div>
     <div
       class="form-body"
-    >
-      <div
-        class="mx-0 alert alert-dismissible alert-fluid alert-warning"
-        role="alert"
-      >
-        <div
-          class="container"
-        >
-          <div
-            class="alert-autofit-row autofit-row"
-          >
-            <div
-              class="autofit-col"
-            >
-              <div
-                class="autofit-section"
-              >
-                <span
-                  class="alert-indicator"
-                >
-                  <svg
-                    class="lexicon-icon lexicon-icon-warning-full"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="#warning-full"
-                    />
-                  </svg>
-                </span>
-              </div>
-            </div>
-            <div
-              class="autofit-col autofit-col-expand"
-            >
-              <div
-                class="autofit-section"
-              >
-                <strong
-                  class="lead"
-                >
-                  segmentation-is-disabled
-                </strong>
-                to-enable-segmentation-go-to-system-settings-segments-segments-service
-              </div>
-            </div>
-          </div>
-          <button
-            aria-label="Close"
-            class="close"
-            type="button"
-          >
-            <svg
-              class="lexicon-icon lexicon-icon-times"
-              role="presentation"
-            >
-              <use
-                xlink:href="#times"
-              />
-            </svg>
-          </button>
-        </div>
-      </div>
-    </div>
+    />
   </div>
 </DocumentFragment>
 `;


### PR DESCRIPTION
- LPS-154019 Dismissible alert for Segmentation when disabled
- LPS-154019 Dismissible alert for Collection creation when Segmentation is disabled
- LPS-154019 Dismissible alert for Experience Selector when Segmentation is disabled
- LPS-154019 Fix tests for ExperienceToolbarSection
- LPS-154019 Update snapshots
- LPS-154019 Remove CSS classes from DOM on alert close
- LPS-154019 Add tests for alert in Segment detail view
- LPS-154019 Fix styles for alert inside dropdown
- LPS-154019 Lang key renaming following LPS-151362#2531
